### PR TITLE
fix: missing endpoints for {predecessor,successor}_versions, fixes #6

### DIFF
--- a/lib/w3c_api/hal.rb
+++ b/lib/w3c_api/hal.rb
@@ -83,6 +83,18 @@ module W3cApi
         model: Models::SpecVersion
       )
       register.add_endpoint(
+        id: :specification_version_predecessors_index,
+        type: :index,
+        url: '/specifications/{shortname}/versions/{version}/predecessors',
+        model: Models::SpecVersionIndex
+      )
+      register.add_endpoint(
+        id: :specification_version_successors_index,
+        type: :index,
+        url: '/specifications/{shortname}/versions/{version}/successors',
+        model: Models::SpecVersionIndex
+      )
+      register.add_endpoint(
         id: :specification_by_status_index,
         type: :index,
         url: '/specifications-by-status/{status}',

--- a/lib/w3c_api/models/spec_version_index.rb
+++ b/lib/w3c_api/models/spec_version_index.rb
@@ -6,6 +6,8 @@ module W3cApi
   module Models
     class SpecVersionIndex < Lutaml::Hal::Page
       hal_link :spec_versions, key: 'version-history', realize_class: 'SpecVersion', collection: true
+      hal_link :predecessor_version, key: 'predecessor-version', realize_class: 'SpecVersionIndex', collection: true
+      hal_link :successor_version, key: 'successor-version', realize_class: 'SpecVersionIndex', collection: true
     end
   end
 end

--- a/spec/w3c_api/models/spec_version_index_spec.rb
+++ b/spec/w3c_api/models/spec_version_index_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe W3cApi::Models::SpecVersionIndex do
+  let(:spec_version_index_hash) do
+    {
+      'total' => 2,
+      'page' => 1,
+      'pages' => 1,
+      'limit' => 25,
+      '_links' => {
+        'self' => {
+          'href' => 'https://api.w3.org/specifications/html5/versions'
+        },
+        'predecessor-version' => [
+          {
+            'href' => 'https://api.w3.org/specifications/html5/versions/20171214',
+            'title' => 'HTML 5.2'
+          }
+        ],
+        'successor-version' => [
+          {
+            'href' => 'https://api.w3.org/specifications/html5/versions/20180327',
+            'title' => 'HTML 5.3'
+          }
+        ]
+      }
+    }
+  end
+
+  let(:spec_version_index) { described_class.from_json(spec_version_index_hash.to_json) }
+
+  describe 'attributes' do
+    it 'has the correct attributes' do
+      expect(spec_version_index).to respond_to(:total)
+      expect(spec_version_index).to respond_to(:page)
+      expect(spec_version_index).to respond_to(:pages)
+      expect(spec_version_index).to respond_to(:limit)
+      expect(spec_version_index).to respond_to(:links)
+    end
+
+    it 'sets attributes correctly from hash' do
+      expect(spec_version_index.total).to eq(2)
+      expect(spec_version_index.page).to eq(1)
+      expect(spec_version_index.pages).to eq(1)
+      expect(spec_version_index.limit).to eq(25)
+    end
+  end
+
+  describe 'HAL links' do
+    it 'returns the correct self link' do
+      expect(spec_version_index.links.self.href).to eq('https://api.w3.org/specifications/html5/versions')
+    end
+
+    it 'has predecessor_version links' do
+      expect(spec_version_index.links).to respond_to(:predecessor_version)
+      expect(spec_version_index.links.predecessor_version).to be_a(Array)
+      expect(spec_version_index.links.predecessor_version.first).to be_a(W3cApi::Models::SpecVersionIndexLink)
+      expect(spec_version_index.links.predecessor_version.first.href).to eq('https://api.w3.org/specifications/html5/versions/20171214')
+      expect(spec_version_index.links.predecessor_version.first.title).to eq('HTML 5.2')
+    end
+
+    it 'has successor_version links' do
+      expect(spec_version_index.links).to respond_to(:successor_version)
+      expect(spec_version_index.links.successor_version).to be_a(Array)
+      expect(spec_version_index.links.successor_version.first).to be_a(W3cApi::Models::SpecVersionIndexLink)
+      expect(spec_version_index.links.successor_version.first.href).to eq('https://api.w3.org/specifications/html5/versions/20180327')
+      expect(spec_version_index.links.successor_version.first.title).to eq('HTML 5.3')
+    end
+  end
+
+  describe 'HAL link realization' do
+    context 'when predecessor_version links exist' do
+      it 'has realize method available' do
+        # The key fix is that these links now have the realize method available
+        # without throwing "Unregistered URL pattern" errors
+        expect(spec_version_index.links.predecessor_version.first).to respond_to(:realize)
+      end
+    end
+
+    context 'when successor_version links exist' do
+      it 'has realize method available' do
+        # The key fix is that these links now have the realize method available
+        # without throwing "Unregistered URL pattern" errors
+        expect(spec_version_index.links.successor_version.first).to respond_to(:realize)
+      end
+    end
+  end
+
+  describe 'serialization' do
+    it 'can be converted to JSON' do
+      json = spec_version_index.to_json
+      expect(json).to be_a(String)
+      expect(json).to include('"total":2')
+      expect(json).to include('"page":1')
+    end
+
+    it 'can be converted to YAML' do
+      yaml = spec_version_index.to_yaml
+      expect(yaml).to be_a(String)
+      expect(yaml).to include('total: 2')
+      expect(yaml).to include('page: 1')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #6

Now:

```ruby
client = W3cApi::Client.new
spec_ver = client.specification_version('webrtc', '20241008')
result = spec_ver.links.predecessor_version.realize
# => #<W3cApi::Models::SpecVersionIndex:0x... @total=1, ...>
```
