### PR TITLE
fix: add pagination and options support to client methods, fixes #4

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -121,6 +121,18 @@ versions = client.specification_versions('webrtc')
 version = client.specification_version('webrtc', '20241008')
 specs_by_status = client.specifications_by_status('Recommendation')
 
+# Get predecessor and successor versions
+predecessors = client.specification_version_predecessors('webrtc', '20241008')
+successors = client.specification_version_successors('webrtc', '20241008')
+
+# Pagination and options support
+# All client methods support pagination and other HTTP options
+specifications = client.specifications(page: 2, per_page: 50)
+groups = client.groups(page: 1, per_page: 10)
+
+# Custom headers and timeouts
+user = client.user('hash', timeout: 30, headers: { 'User-Agent' => 'MyApp/1.0' })
+
 # Work with linked resources directly
 spec = client.specification('webrtc')
 spec_versions = spec.links.versions

--- a/README.adoc
+++ b/README.adoc
@@ -125,13 +125,33 @@ specs_by_status = client.specifications_by_status('Recommendation')
 predecessors = client.specification_version_predecessors('webrtc', '20241008')
 successors = client.specification_version_successors('webrtc', '20241008')
 
-# Pagination and options support
-# All client methods support pagination and other HTTP options
-specifications = client.specifications(page: 2, per_page: 50)
-groups = client.groups(page: 1, per_page: 10)
+# All client methods support comprehensive options including:
 
-# Custom headers and timeouts
+# Pagination options
+specifications = client.specifications(page: 2, per_page: 50)
+groups = client.groups(page: 1, per_page: 10, limit: 25, offset: 100)
+
+# HTTP client options
 user = client.user('hash', timeout: 30, headers: { 'User-Agent' => 'MyApp/1.0' })
+spec = client.specification('html5', read_timeout: 45, open_timeout: 10)
+
+# Query parameters for filtering and sorting
+rec_specs = client.specifications_by_status('REC', sort: 'date', order: 'desc')
+active_groups = client.groups(type: 'working-group', status: 'active')
+
+# Combining multiple options
+options = {
+  page: 1,
+  per_page: 25,
+  headers: { 'Accept-Language' => 'en-US' },
+  timeout: 60,
+  sort: 'name'
+}
+specs = client.specifications(options)
+
+# Backward compatibility - existing code continues to work
+specifications = client.specifications  # No options
+specification = client.specification('webrtc')  # Required params only
 
 # Work with linked resources directly
 spec = client.specification('webrtc')

--- a/lib/w3c_api/client.rb
+++ b/lib/w3c_api/client.rb
@@ -7,95 +7,101 @@ require_relative 'hal'
 
 module W3cApi
   class Client
-    def specifications(options = {})
-      Hal.instance.register.fetch(:specification_index, **options)
+    def specifications(options = nil)
+      fetch_resource(:specification_index, **(options || {}))
     end
 
     def specification(shortname, options = {})
-      Hal.instance.register.fetch(:specification_resource, shortname: shortname, **options)
+      fetch_resource(:specification_resource, shortname: shortname, **options)
     end
 
     def specification_versions(shortname, options = {})
-      Hal.instance.register.fetch(:specification_resource_version_index, shortname: shortname, **options)
+      fetch_resource(:specification_resource_version_index,
+                     shortname: shortname, **options)
     end
 
     def specification_version(shortname, version, options = {})
-      Hal.instance.register.fetch(
+      fetch_resource(
         :specification_resource_version_resource,
         shortname: shortname,
         version: version,
-        **options
+        **options,
       )
     end
 
     def specifications_by_status(status, options = {})
-      Hal.instance.register.fetch(:specification_by_status_index, status: status, **options)
+      fetch_resource(:specification_by_status_index, status: status, **options)
     end
 
     def specification_supersedes(shortname, options = {})
-      Hal.instance.register.fetch(:specification_supersedes_index, shortname: shortname, **options)
+      fetch_resource(:specification_supersedes_index, shortname: shortname,
+                                                      **options)
     end
 
     def specification_superseded_by(shortname, options = {})
-      Hal.instance.register.fetch(:specification_superseded_by_index, shortname: shortname, **options)
+      fetch_resource(:specification_superseded_by_index, shortname: shortname,
+                                                         **options)
     end
 
     # New methods for editors and deliverers
 
     def specification_editors(shortname, options = {})
-      Hal.instance.register.fetch(:specification_editors_index, shortname: shortname, **options)
+      fetch_resource(:specification_editors_index, shortname: shortname,
+                                                   **options)
     end
 
     def specification_deliverers(shortname, options = {})
-      Hal.instance.register.fetch(:specification_deliverers_index, shortname: shortname, **options)
+      fetch_resource(:specification_deliverers_index, shortname: shortname,
+                                                      **options)
     end
 
     # Series methods
 
     def series(options = {})
-      Hal.instance.register.fetch(:serie_index, **options)
+      fetch_resource(:serie_index, **options)
     end
 
     def series_by_shortname(shortname, options = {})
-      Hal.instance.register.fetch(:serie_resource, shortname: shortname, **options)
+      fetch_resource(:serie_resource, shortname: shortname, **options)
     end
 
     def series_specifications(shortname, options = {})
-      Hal.instance.register.fetch(:serie_specification_resource, shortname: shortname, **options)
+      fetch_resource(:serie_specification_resource, shortname: shortname,
+                                                    **options)
     end
 
     # Group methods
 
     def groups(options = {})
-      Hal.instance.register.fetch(:group_index, **options)
+      fetch_resource(:group_index, **options)
     end
 
     def group(id, options = {})
-      Hal.instance.register.fetch(:group_resource, id: id, **options)
+      fetch_resource(:group_resource, id: id, **options)
     end
 
     def group_specifications(id, options = {})
-      Hal.instance.register.fetch(:group_specifications_index, id: id, **options)
+      fetch_resource(:group_specifications_index, id: id, **options)
     end
 
     def group_users(id, options = {})
-      Hal.instance.register.fetch(:group_users_index, id: id, **options)
+      fetch_resource(:group_users_index, id: id, **options)
     end
 
     def group_charters(id, options = {})
-      Hal.instance.register.fetch(:group_charters_index, id: id, **options)
+      fetch_resource(:group_charters_index, id: id, **options)
     end
 
     def group_chairs(id, options = {})
-      Hal.instance.register.fetch(:group_chairs_index, id: id, **options)
+      fetch_resource(:group_chairs_index, id: id, **options)
     end
 
     def group_team_contacts(id, options = {})
-      Hal.instance.register.fetch(:group_team_contacts_index, id: id, **options)
+      fetch_resource(:group_team_contacts_index, id: id, **options)
     end
 
     def group_participations(id, options = {})
-      Hal.instance.register.fetch(:group_participations_index, id: id, **options)
+      fetch_resource(:group_participations_index, id: id, **options)
     end
 
     # User methods
@@ -107,91 +113,103 @@ module W3cApi
     # end
 
     def user(hash, options = {})
-      Hal.instance.register.fetch(:user_resource, hash: hash, **options)
+      fetch_resource(:user_resource, hash: hash, **options)
     end
 
     def user_groups(hash, options = {})
-      Hal.instance.register.fetch(:user_groups_index, hash: hash, **options)
+      fetch_resource(:user_groups_index, hash: hash, **options)
     end
 
     def user_affiliations(hash, options = {})
-      Hal.instance.register.fetch(:user_affiliations_index, hash: hash, **options)
+      fetch_resource(:user_affiliations_index, hash: hash, **options)
     end
 
     def user_participations(hash, options = {})
-      Hal.instance.register.fetch(:user_participations_index, hash: hash, **options)
+      fetch_resource(:user_participations_index, hash: hash, **options)
     end
 
     def user_chair_of_groups(hash, options = {})
-      Hal.instance.register.fetch(:user_chair_of_groups_index, hash: hash, **options)
+      fetch_resource(:user_chair_of_groups_index, hash: hash, **options)
     end
 
     def user_team_contact_of_groups(hash, options = {})
-      Hal.instance.register.fetch(:user_team_contact_of_groups_index, hash: hash, **options)
+      fetch_resource(:user_team_contact_of_groups_index, hash: hash, **options)
     end
 
     def user_specifications(hash, options = {})
-      Hal.instance.register.fetch(:user_specifications_index, hash: hash, **options)
+      fetch_resource(:user_specifications_index, hash: hash, **options)
     end
 
     # Translation methods
 
     def translations(options = {})
-      Hal.instance.register.fetch(:translation_index, **options)
+      fetch_resource(:translation_index, **options)
     end
 
     def translation(id, options = {})
-      Hal.instance.register.fetch(:translation_resource, id: id, **options)
+      fetch_resource(:translation_resource, id: id, **options)
     end
 
     # Affiliation methods
 
     def affiliations(options = {})
-      Hal.instance.register.fetch(:affiliation_index, **options)
+      fetch_resource(:affiliation_index, **options)
     end
 
     def affiliation(id, options = {})
-      Hal.instance.register.fetch(:affiliation_resource, id: id, **options)
+      fetch_resource(:affiliation_resource, id: id, **options)
     end
 
     def affiliation_participants(id, options = {})
-      Hal.instance.register.fetch(:affiliation_participants_index, id: id, **options)
+      fetch_resource(:affiliation_participants_index, id: id, **options)
     end
 
     def affiliation_participations(id, options = {})
-      Hal.instance.register.fetch(:affiliation_participations_index, id: id, **options)
+      fetch_resource(:affiliation_participations_index, id: id, **options)
     end
 
     # Ecosystem methods
 
     def ecosystems(options = {})
-      Hal.instance.register.fetch(:ecosystem_index, **options)
+      fetch_resource(:ecosystem_index, **options)
     end
 
     def ecosystem(id, options = {})
-      Hal.instance.register.fetch(:ecosystem_resource, id: id, **options)
+      fetch_resource(:ecosystem_resource, id: id, **options)
     end
 
     def ecosystem_groups(shortname, options = {})
-      Hal.instance.register.fetch(:ecosystem_groups_index, shortname: shortname, **options)
+      fetch_resource(:ecosystem_groups_index, shortname: shortname, **options)
     end
 
     def ecosystem_evangelists(shortname, options = {})
-      Hal.instance.register.fetch(:ecosystem_evangelists_index, shortname: shortname, **options)
+      fetch_resource(:ecosystem_evangelists_index, shortname: shortname,
+                                                   **options)
     end
 
     def ecosystem_member_organizations(shortname, options = {})
-      Hal.instance.register.fetch(:ecosystem_member_organizations_index, shortname: shortname, **options)
+      fetch_resource(:ecosystem_member_organizations_index,
+                     shortname: shortname, **options)
     end
 
     # Participation methods
 
     def participation(id, options = {})
-      Hal.instance.register.fetch(:participation_resource, id: id, **options)
+      fetch_resource(:participation_resource, id: id, **options)
     end
 
     def participation_participants(id, options = {})
-      Hal.instance.register.fetch(:participation_participants_index, id: id, **options)
+      fetch_resource(:participation_participants_index, id: id, **options)
+    end
+
+    private
+
+    def fetch_resource(resource_key, **params)
+      if params.any?
+        Hal.instance.register.fetch(resource_key, **params)
+      else
+        Hal.instance.register.fetch(resource_key)
+      end
     end
   end
 end

--- a/lib/w3c_api/client.rb
+++ b/lib/w3c_api/client.rb
@@ -20,8 +20,12 @@ module W3cApi
     end
 
     def specification_version(shortname, version, options = {})
-      Hal.instance.register.fetch(:specification_resource_version_resource, shortname: shortname, version: version,
-                                                                            **options)
+      Hal.instance.register.fetch(
+        :specification_resource_version_resource,
+        shortname: shortname,
+        version: version,
+        **options
+      )
     end
 
     def specifications_by_status(status, options = {})
@@ -98,7 +102,8 @@ module W3cApi
 
     # def users(options = {})
     #   raise ArgumentError,
-    #         'The W3C API does not support fetching all users. You must provide a specific user ID with the user method.'
+    #     'The W3C API does not support fetching all users. ' \
+    #     'You must provide a specific user ID with the user method.'
     # end
 
     def user(hash, options = {})

--- a/lib/w3c_api/client.rb
+++ b/lib/w3c_api/client.rb
@@ -8,89 +8,90 @@ require_relative 'hal'
 module W3cApi
   class Client
     def specifications(options = {})
-      Hal.instance.register.fetch(:specification_index)
+      Hal.instance.register.fetch(:specification_index, **options)
     end
 
     def specification(shortname, options = {})
-      Hal.instance.register.fetch(:specification_resource, shortname: shortname)
+      Hal.instance.register.fetch(:specification_resource, shortname: shortname, **options)
     end
 
     def specification_versions(shortname, options = {})
-      Hal.instance.register.fetch(:specification_resource_version_index, shortname: shortname)
+      Hal.instance.register.fetch(:specification_resource_version_index, shortname: shortname, **options)
     end
 
     def specification_version(shortname, version, options = {})
-      Hal.instance.register.fetch(:specification_resource_version_resource, shortname: shortname, version: version)
+      Hal.instance.register.fetch(:specification_resource_version_resource, shortname: shortname, version: version,
+                                                                            **options)
     end
 
     def specifications_by_status(status, options = {})
-      Hal.instance.register.fetch(:specification_by_status_index, status: status)
+      Hal.instance.register.fetch(:specification_by_status_index, status: status, **options)
     end
 
     def specification_supersedes(shortname, options = {})
-      Hal.instance.register.fetch(:specification_supersedes_index, shortname: shortname)
+      Hal.instance.register.fetch(:specification_supersedes_index, shortname: shortname, **options)
     end
 
     def specification_superseded_by(shortname, options = {})
-      Hal.instance.register.fetch(:specification_superseded_by_index, shortname: shortname)
+      Hal.instance.register.fetch(:specification_superseded_by_index, shortname: shortname, **options)
     end
 
     # New methods for editors and deliverers
 
     def specification_editors(shortname, options = {})
-      Hal.instance.register.fetch(:specification_editors_index, shortname: shortname)
+      Hal.instance.register.fetch(:specification_editors_index, shortname: shortname, **options)
     end
 
     def specification_deliverers(shortname, options = {})
-      Hal.instance.register.fetch(:specification_deliverers_index, shortname: shortname)
+      Hal.instance.register.fetch(:specification_deliverers_index, shortname: shortname, **options)
     end
 
     # Series methods
 
     def series(options = {})
-      Hal.instance.register.fetch(:serie_index)
+      Hal.instance.register.fetch(:serie_index, **options)
     end
 
     def series_by_shortname(shortname, options = {})
-      Hal.instance.register.fetch(:serie_resource, shortname: shortname)
+      Hal.instance.register.fetch(:serie_resource, shortname: shortname, **options)
     end
 
     def series_specifications(shortname, options = {})
-      Hal.instance.register.fetch(:serie_specification_resource, shortname: shortname)
+      Hal.instance.register.fetch(:serie_specification_resource, shortname: shortname, **options)
     end
 
     # Group methods
 
     def groups(options = {})
-      Hal.instance.register.fetch(:group_index)
+      Hal.instance.register.fetch(:group_index, **options)
     end
 
     def group(id, options = {})
-      Hal.instance.register.fetch(:group_resource, id: id)
+      Hal.instance.register.fetch(:group_resource, id: id, **options)
     end
 
     def group_specifications(id, options = {})
-      Hal.instance.register.fetch(:group_specifications_index, id: id)
+      Hal.instance.register.fetch(:group_specifications_index, id: id, **options)
     end
 
     def group_users(id, options = {})
-      Hal.instance.register.fetch(:group_users_index, id: id)
+      Hal.instance.register.fetch(:group_users_index, id: id, **options)
     end
 
     def group_charters(id, options = {})
-      Hal.instance.register.fetch(:group_charters_index, id: id)
+      Hal.instance.register.fetch(:group_charters_index, id: id, **options)
     end
 
     def group_chairs(id, options = {})
-      Hal.instance.register.fetch(:group_chairs_index, id: id)
+      Hal.instance.register.fetch(:group_chairs_index, id: id, **options)
     end
 
     def group_team_contacts(id, options = {})
-      Hal.instance.register.fetch(:group_team_contacts_index, id: id)
+      Hal.instance.register.fetch(:group_team_contacts_index, id: id, **options)
     end
 
     def group_participations(id, options = {})
-      Hal.instance.register.fetch(:group_participations_index, id: id)
+      Hal.instance.register.fetch(:group_participations_index, id: id, **options)
     end
 
     # User methods
@@ -101,91 +102,91 @@ module W3cApi
     # end
 
     def user(hash, options = {})
-      Hal.instance.register.fetch(:user_resource, hash: hash)
+      Hal.instance.register.fetch(:user_resource, hash: hash, **options)
     end
 
     def user_groups(hash, options = {})
-      Hal.instance.register.fetch(:user_groups_index, hash: hash)
+      Hal.instance.register.fetch(:user_groups_index, hash: hash, **options)
     end
 
     def user_affiliations(hash, options = {})
-      Hal.instance.register.fetch(:user_affiliations_index, hash: hash)
+      Hal.instance.register.fetch(:user_affiliations_index, hash: hash, **options)
     end
 
     def user_participations(hash, options = {})
-      Hal.instance.register.fetch(:user_participations_index, hash: hash)
+      Hal.instance.register.fetch(:user_participations_index, hash: hash, **options)
     end
 
     def user_chair_of_groups(hash, options = {})
-      Hal.instance.register.fetch(:user_chair_of_groups_index, hash: hash)
+      Hal.instance.register.fetch(:user_chair_of_groups_index, hash: hash, **options)
     end
 
     def user_team_contact_of_groups(hash, options = {})
-      Hal.instance.register.fetch(:user_team_contact_of_groups_index, hash: hash)
+      Hal.instance.register.fetch(:user_team_contact_of_groups_index, hash: hash, **options)
     end
 
     def user_specifications(hash, options = {})
-      Hal.instance.register.fetch(:user_specifications_index, hash: hash)
+      Hal.instance.register.fetch(:user_specifications_index, hash: hash, **options)
     end
 
     # Translation methods
 
     def translations(options = {})
-      Hal.instance.register.fetch(:translation_index)
+      Hal.instance.register.fetch(:translation_index, **options)
     end
 
     def translation(id, options = {})
-      Hal.instance.register.fetch(:translation_resource, id: id)
+      Hal.instance.register.fetch(:translation_resource, id: id, **options)
     end
 
     # Affiliation methods
 
     def affiliations(options = {})
-      Hal.instance.register.fetch(:affiliation_index)
+      Hal.instance.register.fetch(:affiliation_index, **options)
     end
 
     def affiliation(id, options = {})
-      Hal.instance.register.fetch(:affiliation_resource, id: id)
+      Hal.instance.register.fetch(:affiliation_resource, id: id, **options)
     end
 
     def affiliation_participants(id, options = {})
-      Hal.instance.register.fetch(:affiliation_participants_index, id: id)
+      Hal.instance.register.fetch(:affiliation_participants_index, id: id, **options)
     end
 
     def affiliation_participations(id, options = {})
-      Hal.instance.register.fetch(:affiliation_participations_index, id: id)
+      Hal.instance.register.fetch(:affiliation_participations_index, id: id, **options)
     end
 
     # Ecosystem methods
 
     def ecosystems(options = {})
-      Hal.instance.register.fetch(:ecosystem_index)
+      Hal.instance.register.fetch(:ecosystem_index, **options)
     end
 
     def ecosystem(id, options = {})
-      Hal.instance.register.fetch(:ecosystem_resource, id: id)
+      Hal.instance.register.fetch(:ecosystem_resource, id: id, **options)
     end
 
     def ecosystem_groups(shortname, options = {})
-      Hal.instance.register.fetch(:ecosystem_groups_index, shortname: shortname)
+      Hal.instance.register.fetch(:ecosystem_groups_index, shortname: shortname, **options)
     end
 
     def ecosystem_evangelists(shortname, options = {})
-      Hal.instance.register.fetch(:ecosystem_evangelists_index, shortname: shortname)
+      Hal.instance.register.fetch(:ecosystem_evangelists_index, shortname: shortname, **options)
     end
 
     def ecosystem_member_organizations(shortname, options = {})
-      Hal.instance.register.fetch(:ecosystem_member_organizations_index, shortname: shortname)
+      Hal.instance.register.fetch(:ecosystem_member_organizations_index, shortname: shortname, **options)
     end
 
     # Participation methods
 
     def participation(id, options = {})
-      Hal.instance.register.fetch(:participation_resource, id: id)
+      Hal.instance.register.fetch(:participation_resource, id: id, **options)
     end
 
     def participation_participants(id, options = {})
-      Hal.instance.register.fetch(:participation_participants_index, id: id)
+      Hal.instance.register.fetch(:participation_participants_index, id: id, **options)
     end
   end
 end

--- a/spec/w3c_api/client_options_spec.rb
+++ b/spec/w3c_api/client_options_spec.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe W3cApi::Client, 'options support' do
+  let(:client) { described_class.new }
+  let(:mock_register) { instance_double(Lutaml::Hal::ModelRegister) }
+
+  before do
+    allow(W3cApi::Hal.instance).to receive(:register).and_return(mock_register)
+  end
+
+  describe 'pagination options' do
+    it 'passes page parameter to the HAL client' do
+      expect(mock_register).to receive(:fetch).with(:specification_index, page: 2)
+      client.specifications(page: 2)
+    end
+
+    it 'passes per_page parameter to the HAL client' do
+      expect(mock_register).to receive(:fetch).with(:specification_index, per_page: 50)
+      client.specifications(per_page: 50)
+    end
+
+    it 'passes limit parameter to the HAL client' do
+      expect(mock_register).to receive(:fetch).with(:group_index, limit: 25)
+      client.groups(limit: 25)
+    end
+
+    it 'passes offset parameter to the HAL client' do
+      expect(mock_register).to receive(:fetch).with(:affiliation_index, offset: 100)
+      client.affiliations(offset: 100)
+    end
+
+    it 'passes multiple pagination parameters together' do
+      expect(mock_register).to receive(:fetch).with(:specification_index, page: 3, per_page: 20, offset: 40)
+      client.specifications(page: 3, per_page: 20, offset: 40)
+    end
+  end
+
+  describe 'HTTP client options' do
+    it 'passes custom headers to the HAL client' do
+      headers = { 'User-Agent' => 'MyApp/1.0', 'Accept' => 'application/hal+json' }
+      expect(mock_register).to receive(:fetch).with(:user_resource, hash: 'test123', headers: headers)
+      client.user('test123', headers: headers)
+    end
+
+    it 'passes timeout options to the HAL client' do
+      expect(mock_register).to receive(:fetch).with(:group_resource, id: 123, timeout: 30)
+      client.group(123, timeout: 30)
+    end
+
+    it 'passes read_timeout options to the HAL client' do
+      expect(mock_register).to receive(:fetch).with(:specification_resource, shortname: 'html5', read_timeout: 45)
+      client.specification('html5', read_timeout: 45)
+    end
+
+    it 'passes open_timeout options to the HAL client' do
+      expect(mock_register).to receive(:fetch).with(:translation_index, open_timeout: 10)
+      client.translations(open_timeout: 10)
+    end
+  end
+
+  describe 'query parameter options' do
+    it 'passes custom query parameters to the HAL client' do
+      expect(mock_register).to receive(:fetch).with(:specification_by_status_index, status: 'REC', sort: 'date',
+                                                                                    order: 'desc')
+      client.specifications_by_status('REC', sort: 'date', order: 'desc')
+    end
+
+    it 'passes filter parameters to the HAL client' do
+      expect(mock_register).to receive(:fetch).with(:group_index, type: 'working-group', status: 'active')
+      client.groups(type: 'working-group', status: 'active')
+    end
+  end
+
+  describe 'option combinations' do
+    it 'handles pagination and HTTP options together' do
+      options = {
+        page: 2,
+        per_page: 25,
+        headers: { 'User-Agent' => 'TestApp/2.0' },
+        timeout: 60
+      }
+      expect(mock_register).to receive(:fetch).with(:specification_index, **options)
+      client.specifications(options)
+    end
+
+    it 'handles all types of options together' do
+      options = {
+        page: 1,
+        limit: 10,
+        headers: { 'Accept-Language' => 'en-US' },
+        timeout: 30,
+        sort: 'name',
+        filter: 'active'
+      }
+      expect(mock_register).to receive(:fetch).with(:group_index, **options)
+      client.groups(options)
+    end
+  end
+
+  describe 'backward compatibility' do
+    it 'works without any options (empty hash)' do
+      expect(mock_register).to receive(:fetch).with(:specification_index)
+      client.specifications
+    end
+
+    it 'works with empty options hash' do
+      expect(mock_register).to receive(:fetch).with(:specification_index)
+      client.specifications({})
+    end
+
+    it 'preserves existing functionality for required parameters' do
+      expect(mock_register).to receive(:fetch).with(:specification_resource, shortname: 'html5')
+      client.specification('html5')
+    end
+
+    it 'combines required parameters with options' do
+      expect(mock_register).to receive(:fetch).with(
+        :specification_resource,
+        shortname: 'html5',
+        page: 1,
+        headers: { 'Accept' => 'application/json' }
+      )
+      client.specification('html5', page: 1, headers: { 'Accept' => 'application/json' })
+    end
+  end
+
+  describe 'method-specific option passing' do
+    context 'specification methods' do
+      it 'passes options to specification' do
+        expect(mock_register).to receive(:fetch).with(
+          :specification_resource,
+          shortname: 'webrtc',
+          timeout: 20
+        )
+        client.specification('webrtc', timeout: 20)
+      end
+
+      it 'passes options to specification_versions' do
+        expect(mock_register).to receive(:fetch).with(
+          :specification_resource_version_index,
+          shortname: 'webrtc',
+          page: 2
+        )
+        client.specification_versions('webrtc', page: 2)
+      end
+
+      it 'passes options to specification_version' do
+        expect(mock_register).to receive(:fetch).with(
+          :specification_resource_version_resource,
+          shortname: 'webrtc',
+          version: '20241008',
+          headers: { 'Cache-Control' => 'no-cache' }
+        )
+        client.specification_version('webrtc', '20241008', headers: { 'Cache-Control' => 'no-cache' })
+      end
+    end
+
+    context 'group methods' do
+      it 'passes options to group_specifications' do
+        expect(mock_register).to receive(:fetch).with(:group_specifications_index, id: 123, per_page: 15)
+        client.group_specifications(123, per_page: 15)
+      end
+
+      it 'passes options to group_users' do
+        expect(mock_register).to receive(:fetch).with(:group_users_index, id: 456, limit: 50)
+        client.group_users(456, limit: 50)
+      end
+    end
+
+    context 'user methods' do
+      it 'passes options to user_groups' do
+        expect(mock_register).to receive(:fetch).with(:user_groups_index, hash: 'abc123', page: 1, per_page: 10)
+        client.user_groups('abc123', page: 1, per_page: 10)
+      end
+
+      it 'passes options to user_specifications' do
+        expect(mock_register).to receive(:fetch).with(:user_specifications_index, hash: 'def456', sort: 'title')
+        client.user_specifications('def456', sort: 'title')
+      end
+    end
+
+    context 'ecosystem methods' do
+      it 'passes options to ecosystem_groups' do
+        expect(mock_register).to receive(:fetch).with(:ecosystem_groups_index, shortname: 'data', page: 2)
+        client.ecosystem_groups('data', page: 2)
+      end
+    end
+  end
+
+  describe 'edge cases' do
+    it 'handles nil options gracefully' do
+      expect(mock_register).to receive(:fetch).with(:specification_index)
+      client.specifications(nil)
+    end
+
+    it 'handles options with nil values' do
+      expect(mock_register).to receive(:fetch).with(:specification_index, page: nil, per_page: 10)
+      client.specifications(page: nil, per_page: 10)
+    end
+
+    it 'handles string keys in options' do
+      expect(mock_register).to receive(:fetch).with(:specification_index, 'page' => 1, 'per_page' => 20)
+      client.specifications('page' => 1, 'per_page' => 20)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #4

This works now:
```ruby
# Pagination and options support
# All client methods support pagination and other HTTP options
specifications = client.specifications(page: 2, per_page: 50)
groups = client.groups(page: 1, per_page: 10)
```