### PR TITLE
fix: remove duplicated definition of version-history hal_link

### DIFF
--- a/lib/w3c_api/models/specification.rb
+++ b/lib/w3c_api/models/specification.rb
@@ -55,8 +55,6 @@ module W3cApi
       hal_link :supersedes, key: "supersedes",
                             realize_class: "SpecificationIndex", collection: true
       hal_link :series, key: "series", realize_class: "Serie"
-      hal_link :spec_versions, key: "version-history",
-                               realize_class: "SpecVersionIndex"
 
       key_value do
         %i[


### PR DESCRIPTION
Fixes #15

Discovered here:
* https://github.com/lutaml/lutaml-model/pull/451