### PR TITLE
Adopt lutaml-hal 0.2.0 and own W3C rate-limit retries

### DIFF
--- a/lib/w3c_api/hal.rb
+++ b/lib/w3c_api/hal.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "singleton"
+require "faraday/retry"
 require "lutaml/hal"
 require_relative "models"
 
@@ -50,18 +51,55 @@ module W3cApi
     def client
       @client ||= Lutaml::Hal::Client.new(
         api_url: API_URL,
+        connection: connection,
         rate_limiting: rate_limiting_options,
       )
     end
 
+    # Faraday connection mirroring lutaml-hal's default middleware stack, with a
+    # retry layer for the failures lutaml-hal's RateLimiter does not cover: the
+    # W3C API signals rate-limiting with HTTP 403, plus transient connection and
+    # timeout errors. (lutaml-hal still retries 429 and 5xx.) Owning retries here
+    # means every consumer of the client is resilient without its own wrapper.
+    def connection
+      @connection ||= Faraday.new(url: API_URL.delete_suffix("/")) do |conn|
+        conn.request :retry, retry_options
+        conn.use Faraday::FollowRedirects::Middleware
+        conn.request :json
+        conn.response :json, content_type: /\bjson$/
+        conn.adapter Faraday.default_adapter
+      end
+    end
+
+    # Retry policy for the W3C-specific transient failures (HTTP 403 and
+    # connection/timeout). Grows 1, 2, 4, 8, 16s, matching rate_limiting_options.
+    def retry_options
+      {
+        max: 5,
+        interval: 1.0,
+        backoff_factor: 2,
+        max_interval: 30.0,
+        retry_statuses: [403],
+        exceptions: [
+          Errno::ETIMEDOUT, Timeout::Error,
+          Faraday::TimeoutError, Faraday::ConnectionFailed
+        ],
+      }
+    end
+
     # Configure rate limiting options
+    #
+    # lutaml-hal's RateLimiter retries 429 and 5xx responses with exponential
+    # backoff (base_delay * backoff_factor**(attempt - 1), capped at max_delay).
+    # These defaults grow 1, 2, 4, 8, 16s so a rate-limited or briefly
+    # overloaded W3C API is given real room to recover during a bulk crawl.
     def rate_limiting_options
       @rate_limiting_options ||= {
         enabled: true,
         max_retries: 5,
-        base_delay: 0.1,
-        max_delay: 10.0,
-        backoff_factor: 1.5,
+        base_delay: 1.0,
+        max_delay: 30.0,
+        backoff_factor: 2.0,
       }
     end
 

--- a/w3c_api.gemspec
+++ b/w3c_api.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday"
   spec.add_dependency "faraday-follow_redirects"
-  spec.add_dependency "lutaml-hal", "~> 0.1.10"
+  spec.add_dependency "lutaml-hal", "~> 0.2.0"
   spec.add_dependency "lutaml-model", "~> 0.8.0"
   spec.add_dependency "nokogiri"
   spec.add_dependency "rainbow"

--- a/w3c_api.gemspec
+++ b/w3c_api.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday"
   spec.add_dependency "faraday-follow_redirects"
+  spec.add_dependency "faraday-retry", "~> 2.0"
   spec.add_dependency "lutaml-hal", "~> 0.2.0"
   spec.add_dependency "lutaml-model", "~> 0.8.0"
   spec.add_dependency "nokogiri"


### PR DESCRIPTION
## Summary

Two related changes that move w3c_api onto the lutaml-hal 0.2.0 era.

### 1. Depend on lutaml-hal ~> 0.2.0 (`d7bd038`)
lutaml-hal 0.2.0 generalizes the realized-object cache (and pulls in `lutaml-store`). It's a breaking 0.x minor, so the pin moves from `~> 0.1.10` to `~> 0.2.0`. Verified: `bundle install` resolves `lutaml-hal 0.2.0` with `lutaml-store 0.1.1` transitively, and `require "w3c_api"` loads cleanly.

### 2. Own W3C rate-limit + transient retries in the client (`48d6e62`)
The W3C API signals rate-limiting with **HTTP 403**, which lutaml-hal's `RateLimiter` does not retry (it covers 429 and 5xx). w3c_api is the layer that knows this W3C-specific behavior, so it now builds the Faraday connection with a `faraday-retry` layer that retries **403 + connection/timeout**, and passes it to `Lutaml::Hal::Client.new(connection:)`. Every consumer of `W3cApi::Client` is now resilient without its own retry wrapper.

- lutaml-hal still owns 429/5xx; the two retry layers cover disjoint cases (no double-retrying).
- Tuned lutaml-hal's backoff to grow 1, 2, 4, 8, 16s now that it's the primary 429/5xx retry path.
- Adds the `faraday-retry ~> 2.0` dependency.

## Downstream
This lets relaton-w3c drop its `RateLimitHandler` retry logic and rely on the client (a companion relaton-w3c change retries nothing and just memoizes + skips terminal failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)