### PR TITLE
Enable lutaml-hal object cache by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+`w3c_api` is a Ruby client + Thor CLI for the W3C API (https://api.w3.org).
+It is a thin layer over [lutaml-hal](https://github.com/lutaml/lutaml-hal):
+lutaml-hal owns the HTTP client, HAL link realization, and pagination; this gem
+contributes the endpoint registry, the resource models, a convenience `Client`
+facade, and the CLI.
+
+## Commands
+
+```sh
+bundle install              # install dependencies
+bundle exec rake            # default task: spec + rubocop
+bundle exec rake spec       # run all tests
+bundle exec rake rubocop    # lint only
+bundle exec rspec spec/w3c_api/client_spec.rb          # single file
+bundle exec rspec spec/w3c_api/client_spec.rb:42       # single example by line
+exe/w3c_api <command>       # run the CLI without installing
+```
+
+Note: the README's `bin/setup` and `bin/console` do not exist in this repo —
+use `bundle install` and `bundle exec`.
+
+## Architecture
+
+The request path is: **CLI command → `Client` → `Hal` register → lutaml-hal →
+`Models`**.
+
+- **`lib/w3c_api/hal.rb`** — the heart of the gem. `Hal` is a `Singleton` that
+  builds the Faraday connection (with retry + cache config) and registers
+  *every* API endpoint in `setup`
+  (one `add_endpoint` call per endpoint, mapping an endpoint id like
+  `:specification_resource` → URL template + model + parameters). To add or
+  change an API endpoint, edit `setup` here. `SimpleParameter` exists only to
+  satisfy lutaml-hal's parameter-validation interface without pulling in its
+  full `EndpointParameter` machinery.
+
+- **`lib/w3c_api/client.rb`** — `Client` is a flat convenience facade. Almost
+  every method is one line delegating to `Hal.instance.register.fetch(endpoint_id, **params)`
+  via the private `fetch_resource`. Many method families
+  (`group_*`, `user_*`, `affiliation_*`, `ecosystem_*`) are generated with
+  `define_method` loops — follow that pattern rather than writing them out.
+
+- **`lib/w3c_api/models/`** — one file per resource. Two kinds:
+  - **Resources** subclass `Lutaml::Hal::Resource` (e.g. `Specification`).
+  - **Indexes** subclass `Lutaml::Hal::Page` (e.g. `SpecificationIndex`) and
+    provide pagination.
+  Models declare attributes, `hal_link` relationships (each link names a
+  `realize_class` and may be a `collection`), and a `key_value` block mapping
+  the API's hyphenated JSON keys (`series-version`) to underscored Ruby
+  attributes (`series_version`). `models.rb` requires every model file.
+
+- **`lib/w3c_api/commands/`** — one Thor class per resource, all wired into the
+  root `Cli` in `cli.rb` as subcommands. Commands instantiate `Client`, call
+  it, and print via the shared `OutputFormatter` (`--format yaml|json`, YAML
+  default). `exe/w3c_api` is the executable.
+
+### HAL link realization
+
+The defining feature: links are lazy. Calling `.realize` on a link follows its
+`href` and returns the typed model — and chains
+(`spec.links.latest_version.realize.links.editors...`). With `embed: true` on
+supported index endpoints (`:specification_index`, `:group_index`,
+`:serie_index`), the index response embeds child resources and `.realize` uses
+that embedded data instead of issuing a new HTTP request (see
+`lib/w3c_api/embed.rb` and `Client.embed_supported_endpoints`).
+
+### Rate limiting & retries (`hal.rb`)
+
+Two cooperating layers, both tuned to grow 1→2→4→8→16s:
+- lutaml-hal's `RateLimiter` (via `rate_limiting_options`) retries **429 and
+  5xx**.
+- A Faraday `:retry` middleware in `connection` covers what lutaml-hal does not:
+  the W3C API signals rate-limiting with **HTTP 403**, plus connection/timeout
+  errors.
+
+Owning retries in the client means consumers get resilience without wrapping.
+Tune via `Hal.instance.configure_rate_limiting(...)`; changing options resets
+the memoized client.
+
+### Caching (`hal.rb`)
+
+lutaml-hal caches realized objects keyed by their canonical URL, so a document
+linked from many places (editors, working groups, versions) is fetched once per
+process. It is **enabled by default** (in-memory) — the register is built with
+`cache: cache_options`. Tune or persist via `Hal.instance.configure_cache(...)`
+(e.g. a `:filesystem` adapter) or turn it off with `disable_cache`; like the
+rate-limiting setters these rebuild the register. `reset_register` also
+unregisters from lutaml-hal's `GlobalRegister`, otherwise the rebuild raises
+"replacing another one".
+
+## Testing
+
+Specs use **VCR** (`hook_into :faraday`) with cassettes in
+`spec/fixtures/vcr_cassettes/`. Default record mode is `:new_episodes` and
+requests match on `method, uri, body` — so a new test that hits an unrecorded
+request will perform a real HTTP call and record it. `spec_helper.rb` resets the
+`Hal` singleton's register and the lutaml-hal `GlobalRegister` around every
+example to prevent cross-test endpoint-registration bleed — which also gives
+each example a fresh object cache, so caching doesn't mask expected requests.
+
+## Conventions
+
+- Ruby >= 3.1. RuboCop inherits Ribose's shared OSS config; `LineLength` max is
+  180. `.rubocop_todo.yml` holds grandfathered offences — prefer fixing over
+  growing it.
+- Endpoint ids follow `<resource>_resource` (single) / `<resource>_index`
+  (collection) naming; keep new ids consistent so the `define_method` loops and
+  `embed_supported?` discovery keep working.

--- a/README.adoc
+++ b/README.adoc
@@ -123,6 +123,36 @@ The stress test example demonstrates:
 * Dynamic configuration changes
 * Bulk operation patterns
 
+=== Caching
+
+Realized objects are cached keyed by their (canonical) URL, so a resource linked from many places — editors, working groups, versions — is fetched only once per process. Caching is enabled by default (in-memory) and works transparently with `fetch` and link `.realize`.
+
+==== Quick start
+
+[source,ruby]
+----
+require 'w3c_api'
+
+# Object caching is enabled by default (in-memory)
+client = W3cApi::Client.new
+
+# The same linked resource is fetched once, then served from cache
+specs = client.specifications
+spec = specs.links.specifications.first.realize   # HTTP request
+spec.links.latest_version.realize                 # HTTP request
+spec.links.latest_version.realize                 # cache hit, no HTTP
+
+# Disable caching entirely
+W3cApi::Hal.instance.disable_cache
+
+# Or persist the cache across runs on disk
+W3cApi::Hal.instance.configure_cache(
+  adapter: { type: :filesystem, options: { path: "tmp/w3c_cache" } }
+)
+----
+
+The cache is backed by https://github.com/lutaml/lutaml-store[lutaml-store]: the default `:memory` adapter lives for the process, while the `:filesystem` (and `:sqlite`) adapters persist across runs.
+
 === Embed support with auto-realize
 
 ==== General

--- a/lib/w3c_api/hal.rb
+++ b/lib/w3c_api/hal.rb
@@ -120,10 +120,45 @@ module W3cApi
       configure_rate_limiting(enabled: true)
     end
 
+    # Cache options for the model register
+    #
+    # lutaml-hal caches realized objects keyed by their (canonical) URL, so a
+    # document linked from many places is fetched once. In-memory by default;
+    # pass an adapter config such as
+    # `{ adapter: { type: :filesystem, options: { path: "..." } } }` for
+    # cross-run persistence. Returns nil when caching is disabled.
+    def cache_options
+      return @cache_options if defined?(@cache_options)
+
+      @cache_options = { adapter: :memory }
+    end
+
+    # Set cache options (merged into the current ones)
+    def configure_cache(options = {})
+      @cache_options = (cache_options || {}).merge(options)
+      reset_register
+    end
+
+    # Disable caching of realized objects
+    def disable_cache
+      @cache_options = nil
+      reset_register
+    end
+
+    # Enable caching of realized objects
+    def enable_cache(options = nil)
+      @cache_options = options || { adapter: :memory }
+      reset_register
+    end
+
     def register
       return @register if @register
 
-      @register = Lutaml::Hal::ModelRegister.new(name: :w3c_api, client: client)
+      @register = Lutaml::Hal::ModelRegister.new(
+        name: :w3c_api,
+        client: client,
+        cache: cache_options,
+      )
       Lutaml::Hal::GlobalRegister.instance.register(:w3c_api, @register)
 
       # Re-run setup to register all endpoints with the new register
@@ -133,6 +168,9 @@ module W3cApi
     end
 
     def reset_register
+      # Drop the global registration too, otherwise rebuilding the register
+      # raises "replacing another one" when it re-registers the same name.
+      Lutaml::Hal::GlobalRegister.instance.unregister(:w3c_api)
       @register = nil
     end
 


### PR DESCRIPTION
## Summary

lutaml-hal 0.2.0 caches realized objects keyed by canonical URL, but it's opt-in and the register was created without it — so a document linked from many places was re-fetched every time. This turns it on.

- **Enable the cache** — build the register with `cache: cache_options` (in-memory by default). Repeat `fetch`/`realize` of the same URL are served locally.
- **Config knobs** mirroring the rate-limiting setters: `configure_cache` / `enable_cache` / `disable_cache` (e.g. a `:filesystem` adapter for cross-run persistence).
- **Fix `reset_register`** to also unregister from lutaml-hal's `GlobalRegister`, otherwise rebuilding on reconfigure raises "replacing another one" (a pre-existing latent bug).
- Document the cache in README and CLAUDE.md.

## Verification

- 3 fetches of one resource → **1 HTTP request**.
- Full suite green: **224 examples, 0 failures** (the per-example register reset keeps each example's cache fresh, so VCR matching is unaffected).

Backward-compatible (additive config methods + a transparent per-process optimization), so this is a **patch (0.3.1)** — `~> 0.3.0` consumers (relaton-w3c) auto-adopt the caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)