### PR TITLE
Require lutaml-hal ~> 0.2.1 (thread-safe cache)

### DIFF
--- a/w3c_api.gemspec
+++ b/w3c_api.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday"
   spec.add_dependency "faraday-follow_redirects"
   spec.add_dependency "faraday-retry", "~> 2.0"
-  spec.add_dependency "lutaml-hal", "~> 0.2.0"
+  spec.add_dependency "lutaml-hal", "~> 0.2.1"
   spec.add_dependency "lutaml-model", "~> 0.8.0"
   spec.add_dependency "nokogiri"
   spec.add_dependency "rainbow"


### PR DESCRIPTION
The default object cache is shared across threads (consumers realize links from parallel fetchers). lutaml-hal 0.2.1 makes its in-memory cache store thread-safe; require it. Patch release (0.3.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)